### PR TITLE
Fixed main async loop from choking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 # bot.py
 
 # --------Modules---------------------------
-DEBUG = False
+DEBUG = True
 
 import asyncio
 import datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 dnspython==1.16.0
 PyNaCl==1.4.0
 async-timeout==3.0.1
-discord.py==2.1.0
+discord.py==2.3.2
 tinydb==4.3.0
 GitPython==3.1.12
-Pillow==9.3.0
+Pillow==11.1.0
 requests==2.22.0
 colorthief==0.2.1
 webcolors==1.3
 python-dotenv==0.19.0
 pytz==2022.6
-b2sdk==1.26.0
+b2sdk==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ webcolors==1.3
 python-dotenv==0.19.0
 pytz==2022.6
 b2sdk==2.8.0
+asyncify-python==2.1.0


### PR DESCRIPTION
Since a couple of weeks ago the bot has been getting stuck when trying to push shots. Apparently, it had to do with some heavy tasks, like downloading big images from Discord and uploading them again to Backblaze, to block the bot and getting in some sort of deadlock state.

So to fix it (as far as I understand), we spawned these tasks as coroutines and forced them to yield, so they don't block the main thread/loop from continuing. Huge thanks to @FransBouma for helping out with this!

I also took this opportunity to do some other fixes and improvements, such as:
- Resize image thumbnails using lancoz
- Cleaned up logging
- Garbage collector management to fight memory leaks
- Updated some libraries
- Ordered the imports list
- Polished the hof hitrate report
- Uncommented the scheduled hof hitrate report
- Solved #7 
